### PR TITLE
Systemd user autojack wrapper

### DIFF
--- a/usr/bin/autojack-start
+++ b/usr/bin/autojack-start
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Pulseaudio is starting as a systemd user service in newer versions of OS's.
+# Restarting this systemd service prior to autojack start fixes
+# a problem where pulseaudio bridges cannot start.
+
+/usr/bin/systemctl --user restart pulseaudio || true
+/usr/bin/autojack

--- a/usr/lib/systemd/user/studio.service
+++ b/usr/lib/systemd/user/studio.service
@@ -6,9 +6,10 @@ Description=Studio autojack session daemon
 # changing various settings.
 BindsTo=default.target
 Before=default.target
+After=pulseaudio.service
 
 [Service]
-ExecStart=/usr/bin/autojack
+ExecStart=/usr/bin/autojack-start
 
 
 [Install]


### PR DESCRIPTION
This fixes a problem where, in newer OS's (such as Ubuntu 21.10 and later) the pulseaudio bridges would fail to start. This is because we're calling the pulseaudio restart, but pulseaudio never properly initiates. This solves/works-around the problem by restarting pulseaudio prior to autojack start.